### PR TITLE
fix: add react-hooks to eslint plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
     "airbnb/hooks",
     "prettier",
   ],
-  plugins: ["react", "@typescript-eslint", "jsx-a11y", "import", "jest"],
+  plugins: ["react", "@typescript-eslint", "jsx-a11y", "import", "jest", "react-hooks"],
   rules: {
     "no-unused-vars": "off",
     semi: ["error", "always"],


### PR DESCRIPTION
This PR fixes `Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps` error 
