### PR TITLE
feat(client): Add Cypress end-to-end test and configure webpack-dev-server for Cypress

### DIFF
--- a/client/cypress.config.ts
+++ b/client/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+  },
+  component: {
+    devServer: {
+      framework: 'next',
+      bundler: 'webpack',
+    },
+  },
+})

--- a/client/cypress/e2e/login.cy.ts
+++ b/client/cypress/e2e/login.cy.ts
@@ -1,0 +1,12 @@
+describe('Login Test', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.fixture('login.json').then((loginData) => {
+      cy.login(loginData.email, loginData.password);
+    });
+  });
+  
+  it('should log in successfully and redirect to the dashboard', () => {
+    cy.url().should('include', '/');
+  });
+});

--- a/client/cypress/fixtures/login.json
+++ b/client/cypress/fixtures/login.json
@@ -1,0 +1,5 @@
+{
+    "email": "mertgold60@gmail.com",
+    "password": "mert1234567"
+  }
+  

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -1,0 +1,60 @@
+/// <reference types="cypress" />
+import './commands';
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }
+
+declare global {
+    namespace Cypress {
+      interface Chainable {
+        login(username: string, password: string): Chainable<void>;
+      }
+    }
+  }
+  
+  Cypress.Commands.add('login', (username: string, password: string) => {
+    cy.visit('/');
+
+    cy.get('#login-inputs').as('loginInputs');
+    cy.get('@loginInputs').find('input').eq(0).type(username);
+
+    cy.wait(1000)
+
+    cy.get('@loginInputs').find('input').eq(1).type(password);
+
+    cy.get('#login-btn').click();
+  });
+  

--- a/client/cypress/support/component-index.html
+++ b/client/cypress/support/component-index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+    <!-- Used by Next.js to inject CSS. -->
+    <div id="__next_css__DO_NOT_USE__"></div>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/client/cypress/support/component.ts
+++ b/client/cypress/support/component.ts
@@ -1,0 +1,39 @@
+// ***********************************************************
+// This example support/component.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+import { mount } from 'cypress/react18'
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+Cypress.Commands.add('mount', mount)
+
+// Example use:
+// cy.mount(<MyComponent />)

--- a/client/cypress/support/e2e.ts
+++ b/client/cypress/support/e2e.ts
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/client/cypress/tsconfig.json
+++ b/client/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+      "target": "es5",
+      "lib": ["es5", "dom"],
+      "types": ["cypress", "node"]
+    },
+    "include": ["**/*.ts"]
+  }

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -12,6 +12,15 @@ const nextConfig = {
     domains: ["t1.gstatic.com"],
   },
   swcMinify: true,
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.devServer = {
+        hot: true,
+        liveReload: false,
+      };
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "e2e": "start-server-and-test dev http://localhost:3000 \"cypress open --e2e\"",
+    "e2e:headless": "start-server-and-test dev http://localhost:3000 \"cypress run --e2e\"",
+    "component": "cypress open --component",
+    "component:headless": "cypress run --component"
   },
   "dependencies": {
     "apexcharts": "^3.36.3",
@@ -38,6 +42,7 @@
     "@types/react-virtualized": "^9.21.21",
     "@types/react-window": "^1.8.5",
     "autoprefixer": "^10.4.7",
+    "cypress": "^12.14.0",
     "eslint": "8.17.0",
     "eslint-config-next": "^13.1.1",
     "jest": "^28.1.0",
@@ -45,7 +50,8 @@
     "postcss-import": "^14.1.0",
     "sass": "^1.52.2",
     "tailwindcss": "^3.1.4",
-    "typescript": "4.7.3"
+    "typescript": "4.7.3",
+    "webpack-dev-server": "^4.15.1"
   },
   "resolutions": {
     "@types/react": "18.0.14",

--- a/client/src/modules/Login/components/LoginForm/index.tsx
+++ b/client/src/modules/Login/components/LoginForm/index.tsx
@@ -51,7 +51,7 @@ const LoginForm: FC = () => {
           {t("signup_redirection_part_2")}
         </p>
       </div>
-      <div className="flex flex-col gap-4 mb-5">
+      <div id="login-inputs" className="flex flex-col gap-4 mb-5">
         <TextField
           name="email"
           type="email"
@@ -77,7 +77,7 @@ const LoginForm: FC = () => {
         </Link>
       </div>
       <div className="flex flex-col gap-6">
-        <Button type="submit" size="large" fluid>
+        <Button id="login-btn" type="submit" size="large" fluid>
           {t("login")}
         </Button>
         <div className="divider mt-0 mb-0 text-slate-300 select-none">OR</div>


### PR DESCRIPTION
This commit introduces an end-to-end test using Cypress to ensure the overall functionality of the project. Additionally, webpack-dev-server has been configured specifically for Cypress component tests, enabling faster and more efficient testing of individual components. These updates enhance the testing capabilities of the project and improve the overall development workflow fyi @kayraberktuncer 👨‍🚀 

